### PR TITLE
Slight adjustment to CORS configuration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -96,7 +96,7 @@ const createApp = () => {
 
   if (process.env.CORS){
     const corsOptions = {
-      origin: "chrome://*",
+      origin: "*", // CORS does not support wildcards except exactly "*"
       credentials: true,
       allowedHeaders: ["Content-Type", "Authorization"]
     }


### PR DESCRIPTION
Wildcards as part of larger string don't work, for example: "chrome://*". This change adjusts the string to be "*".

Allowing all origins is a temporary workaround for the CORS issue with Chrome extensions. Moving forward, the idea is to use XMLHTTPRequest and the CORS whitelist in the extension's manifest.json.