### PR TITLE
Adjust Travis config to reenable production deployments 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ before_deploy:
 - chmod 600 /tmp/deploy_rsa
 - ssh-add /tmp/deploy_rsa
 deploy:
-  provider: script
-  skip_cleanup: true
-  script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-master.sh'
-  on:
-    branch: master
-  provider: script
-  skip_cleanup: true
-  script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-qa.sh'
-  on:
-    branch: qa
+  - provider: script
+    skip_cleanup: true
+    script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-master.sh'
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-qa.sh'
+    on:
+      branch: qa

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ before_deploy:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-master.sh'
-    on:
-      branch: master
-  - provider: script
-    skip_cleanup: true
     script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-qa.sh'
     on:
       branch: qa
+  - provider: script
+    skip_cleanup: true
+    script: ssh -o "StrictHostKeyChecking no" simmer@simmer.brook.li 'bash ./simmer-deploy-master.sh'
+    on:
+      branch: master


### PR DESCRIPTION
Syntax error prevented push to master from triggering deployment to production.

Tested corrected syntax on the qa branch. Production deployments should work again once this change is made.