### PR TITLE
article view now loads at top of page by default

### DIFF
--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -11,6 +11,7 @@ import {
 
 class Article extends Component {
   componentDidMount() {
+    window.scrollTo(0,0)
     this.props.loadSingleArticle(this.props.match.params.id);
   }
 


### PR DESCRIPTION
Fixed small bug with single article view. Before, page would load wherever user was on previous page (ex. if at bottom of homepage, single article would load at the bottom). Now article view starts at the top by default.